### PR TITLE
Added missing build context for tamarin image build

### DIFF
--- a/Tamarin/README.md
+++ b/Tamarin/README.md
@@ -19,7 +19,7 @@ If you unzip the examples in this directory, you can launch the tamarin prover i
 ## Option 2: Use Docker
 
 ```
-docker build -t tamarin
+docker build -t tamarin .
 mkdir tamarin
 chmod a+rwx tamarin
 docker run -t --net=host --publish 3001:3001 --volume $(pwd)/tamarin:/workspace tamarin


### PR DESCRIPTION
As indicated in the title of this PR, there was a typo in the docker instructions to build the tamarin image (the build context was missing, i.e. `.` (the current directory)). This PR adds it.